### PR TITLE
i18n refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.3
+- move vue-i18n to peerDependencies
+- refactor
+
 ### 0.1.2
 - Pass `props.locale` directly to `useLocale()` instead of `immediate` watcher
 - Move `editor-ready` logic to `getTiptapEditor` `onCreate` callback

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -14,7 +14,10 @@ export default defineConfig({
 
   vite: {
     ssr: {
-      noExternal: ['vuetify'],
+      noExternal: ['vuetify', 'vue-i18n'],
+    },
+    define: {
+      __VUE_PROD_DEVTOOLS__: false,
     },
     optimizeDeps: {
       include: ['vuetify'],

--- a/docs/.vitepress/theme/components/InteractiveEditor.vue
+++ b/docs/.vitepress/theme/components/InteractiveEditor.vue
@@ -45,7 +45,6 @@ onMounted(() => {
   <div class="interactive-editor">
     <Tiptapify
       v-model="content"
-      locale="en"
       :height="height"
       :placeholder="placeholder"
       font-measure="pt"

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -11,6 +11,8 @@ import * as directives from 'vuetify/directives'
 import TiptapifyPlugin from '@tiptapify'
 import '@tiptapifyDist/tiptapify.css'
 
+import { createI18n } from 'vue-i18n'
+
 const vuetify = createVuetify({
   ssr: true,
   components,
@@ -60,8 +62,14 @@ export default {
     })
   },
   enhanceApp({ app }) {
+    const i18n = createI18n({
+      locale: 'en',
+      legacy: false,
+      fallbackLocale: 'en',
+    })
     app.use(vuetify)
-    app.use(TiptapifyPlugin, { locale: 'en' })
+    app.use(i18n)
+    app.use(TiptapifyPlugin, { i18n })
 
     app.component('InteractiveEditor', InteractiveEditor)
   },

--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -17,16 +17,7 @@ Initial editor content. Accepts HTML string or Tiptap JSON object.
 <Tiptapify :content="{ type: 'doc', content: [{ type: 'paragraph' }] }" />
 ```
 
-### `locale`
 
-- **Type:** `String`
-- **Default:** `'en'`
-
-Editor UI language. See [available locales](/guide/i18n#available-locales).
-
-```vue
-<Tiptapify locale="de" />
-```
 
 ### `placeholder`
 
@@ -230,7 +221,7 @@ Fired when the editor instance is ready.
 
 ```typescript
 interface EditorReadyPayload {
-  editor: Editor        // Raw Tiptap Editor instance
+  editor: TiptapEditor  // Raw Tiptap Editor instance
   getHTML: () => string  // Get current HTML content
   getJSON: () => object  // Get current JSON content
 }
@@ -291,11 +282,11 @@ const content = ref('<p>Hello</p>')
 
 ## Provide / Inject
 
-The editor instance and i18n functions are available via Vue's provide/inject:
+The editor instance and `t` function are available via Vue's provide/inject:
 
 ```typescript
 import { inject } from 'vue'
 
 const editor = inject('tiptapifyEditor')
-const { t, setLocale } = inject('tiptapifyI18n')
+const { t } = inject('tiptapifyI18n')
 ```

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -92,12 +92,12 @@ interface ContentChangedPayload {
 }
 ```
 
-## PackageOptions
+## TiptapifyOptions
 
 Options passed when installing the plugin.
 
 ```typescript
-interface PackageOptions {
-  locale?: string  // Default locale (default: 'en')
+interface TiptapifyOptions {
+  i18n: I18n  // vue-i18n instance
 }
 ```

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -15,8 +15,6 @@ const content = ref('<p>Hello, <strong>world</strong>!</p>')
   <Tiptapify
     v-model="content"
     placeholder="Write something..."
-    locale="en"
-    font-measure="pt"
     :bubble-menu="true"
     :floating-menu="false"
     :slash-commands="true"
@@ -45,8 +43,6 @@ const onContentChanged = ({ html, json }) => {
     <Tiptapify
       :content="'<p>Start writing...</p>'"
       placeholder="Write something..."
-      locale="en"
-      font-measure="pt"
       :bubble-menu="true"
       :floating-menu="false"
       :slash-commands="true"
@@ -82,8 +78,6 @@ const onEditorReady = (options) => {
 <template>
   <Tiptapify
     placeholder="Editor with ready callback..."
-    locale="en"
-    font-measure="pt"
     :bubble-menu="true"
     :floating-menu="false"
     :slash-commands="true"
@@ -102,8 +96,6 @@ Set a minimum height for the editor area:
     :content="'<p>Content area with fixed height...</p>'"
     :height="400"
     placeholder="This editor has a fixed height of 400px..."
-    locale="en"
-    font-measure="pt"
     :bubble-menu="true"
     :floating-menu="false"
     :slash-commands="true"
@@ -121,8 +113,6 @@ Hide the toolbar completely and use only the bubble menu:
     :toolbar="false"
     :bubble-menu="true"
     placeholder="Toolbar hidden, use bubble menu..."
-    locale="en"
-    font-measure="pt"
     :floating-menu="false"
     :slash-commands="true"
   />
@@ -153,8 +143,6 @@ const onEditorReady = (options) => {
     <Tiptapify
       :content="'<p>Try editing this content...</p>'"
       :toolbar="false"
-      locale="en"
-      font-measure="pt"
       :bubble-menu="true"
       :floating-menu="false"
       :slash-commands="true"

--- a/docs/examples/i18n.md
+++ b/docs/examples/i18n.md
@@ -8,9 +8,9 @@ Switch the editor language at runtime:
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
-const locale = ref('en')
+const { locale } = useI18n()
 
 const languages = [
   { code: 'en', name: 'English' },
@@ -30,7 +30,7 @@ const languages = [
       label="Language"
     />
 
-    <Tiptapify :locale="locale" />
+    <Tiptapify />
   </div>
 </template>
 ```
@@ -54,16 +54,25 @@ const languages = [
 
 ## Multiple Editors with Different Locales
 
+Use `vue-i18n`'s scoped locales for per-instance languages:
+
 ```vue
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const en = useI18n({ useScope: 'local', locale: 'en' })
+const de = useI18n({ useScope: 'local', locale: 'de' })
+</script>
+
 <template>
   <v-row>
     <v-col>
       <h3>English</h3>
-      <Tiptapify locale="en" />
+      <Tiptapify />
     </v-col>
     <v-col>
       <h3>German</h3>
-      <Tiptapify locale="de" />
+      <Tiptapify />
     </v-col>
   </v-row>
 </template>

--- a/docs/guide/i18n.md
+++ b/docs/guide/i18n.md
@@ -4,25 +4,32 @@ Tiptapify supports **20+ languages** out of the box. Translations are managed vi
 
 ## Setting the Default Locale
 
-Pass the locale when registering the plugin:
+Create a `vue-i18n` instance and pass it when registering the plugin:
 
 ```typescript
 // main.ts
+import { createI18n } from 'vue-i18n'
 import TiptapifyPlugin from 'tiptapify'
 import 'tiptapify/style.css'
 
-app.use(TiptapifyPlugin, { locale: 'de' })
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+})
+
+app.use(i18n)
+app.use(TiptapifyPlugin, { i18n })
 ```
 
 ## Changing Locale at Runtime
 
-Use the `locale` prop on the component to change the language:
+Tiptapify uses your `vue-i18n` instance — change the locale via `useI18n()`:
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
-const currentLocale = ref('en')
+const { locale } = useI18n()
 
 const languages = [
   { code: 'en', label: 'English' },
@@ -36,17 +43,14 @@ const languages = [
 <template>
   <div>
     <v-select
-      v-model="currentLocale"
+      v-model="locale"
       :items="languages"
       item-title="label"
       item-value="code"
       label="Language"
     />
 
-    <Tiptapify
-      :locale="currentLocale"
-      placeholder="Start writing..."
-    />
+    <Tiptapify placeholder="Start writing..." />
   </div>
 </template>
 ```
@@ -87,37 +91,43 @@ Most translations are AI-generated and may contain mistakes. If you find an inco
 
 ## Adding Custom Translations
 
-You can extend or override translations by providing your own locale file:
-
-```typescript
-// src/i18n/locales/custom-en.json
-{
-  "content": {
-    "placeholder": "Write your story..."
-  },
-  "toolbar": {
-    "bold": "Make bold",
-    "italic": "Make italic"
-  }
-}
-```
-
-Then merge it with the existing locale:
+Tiptapify automatically merges its built-in locale messages into your `vue-i18n` instance when you pass it to the plugin. You can extend or override translations before registering the plugin:
 
 ```typescript
 import { createI18n } from 'vue-i18n'
-import en from 'tiptapify/src/i18n/locales/en.json'
-import customEn from './custom-en.json'
+import TiptapifyPlugin from 'tiptapify'
+import 'tiptapify/style.css'
 
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
   messages: {
-    en: { ...en, ...customEn },
+    // Custom translations take precedence over Tiptapify's built-in ones
+    en: {
+      toolbar: {
+        bold: 'Make bold',
+        italic: 'Make italic',
+      },
+    },
   },
 })
 
 app.use(i18n)
+app.use(TiptapifyPlugin, { i18n })
+```
+
+Or merge after creating the i18n instance:
+
+```typescript
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+})
+
+i18n.global.mergeLocaleMessage('en', customTranslations)
+
+app.use(i18n)
+app.use(TiptapifyPlugin, { i18n })
 ```
 
 ## RTL Languages
@@ -134,19 +144,16 @@ const vuetify = createVuetify({
 
 ## Per-Instance Locale
 
-Each `<Tiptapify>` instance can have its own locale independently:
+Tiptapify uses your app's `vue-i18n` locale globally. If you need per-instance locales, use `vue-i18n`'s scoped slots or composition API within the instance's scope:
 
 ```vue
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t, locale } = useI18n({ useScope: 'local' })
+</script>
+
 <template>
-  <v-row>
-    <v-col>
-      <h3>English</h3>
-      <Tiptapify locale="en" placeholder="Write in English..." />
-    </v-col>
-    <v-col>
-      <h3>Deutsch</h3>
-      <Tiptapify locale="de" placeholder="Auf Deutsch schreiben..." />
-    </v-col>
-  </v-row>
+  <Tiptapify :placeholder="t('editor.placeholder')" />
 </template>
 ```

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -3,6 +3,7 @@
 ## Requirements
 
 - **Vue 3.5+**
+- **vue-i18n 11+**
 - **Vuetify 3.8+ or Vuetify 4.x**
 - **@mdi/js** (Material Design Icons)
 
@@ -29,7 +30,7 @@ yarn add tiptapify
 Tiptapify requires the following peer dependencies. Make sure they are installed in your project:
 
 ```bash
-npm i @mdi/js vue vuetify
+npm i @mdi/js vue vue-i18n vuetify
 ```
 
 ## Vuetify Setup
@@ -65,10 +66,17 @@ app.mount('#app')
 In your app entry file, import and register the Tiptapify plugin:
 
 ```typescript
+import { createI18n } from 'vue-i18n'
 import TiptapifyPlugin from 'tiptapify'
 import 'tiptapify/style.css'
 
-app.use(TiptapifyPlugin, { locale: 'en' })
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+})
+
+app.use(i18n)
+app.use(TiptapifyPlugin, { i18n })
 ```
 
 ## Full Example
@@ -84,8 +92,14 @@ import { aliases, mdi } from 'vuetify/iconsets/mdi-svg'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 
+import { createI18n } from 'vue-i18n'
 import TiptapifyPlugin from 'tiptapify'
 import 'tiptapify/style.css'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+})
 
 const vuetify = createVuetify({
   components,
@@ -100,7 +114,8 @@ const vuetify = createVuetify({
 const app = createApp(App)
 
 app.use(vuetify)
-app.use(TiptapifyPlugin, { locale: 'en' })
+app.use(i18n)
+app.use(TiptapifyPlugin, { i18n })
 
 app.mount('#app')
 ```

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -71,7 +71,6 @@ const handleContentChanged = ({ html, json }) => {
   <v-container>
     <Tiptapify
       :content="'<p>Start typing...</p>'"
-      locale="en"
       :height="400"
       :toolbar="true"
       :items="['bold', 'italic', 'underline', 'strike', '|', 'heading', 'bulletList', 'orderedList', '|', 'link', 'image', '|', 'undo', 'redo']"
@@ -162,6 +161,6 @@ See the [Toolbar Items](/api/toolbar-items) reference for all available items, a
 ## Next Steps
 
 - Learn about [Toolbar Configuration](/examples/custom-toolbar)
-- Set up [Internationalization](/guide/i18n)
+- Set up [Internationalization](/guide/i18n) (requires `vue-i18n`)
 - Explore [Media Embedding](/examples/media)
 - See the full [API Reference](/api/props)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ This project is currently in **Beta**. It is feature-complete but may still have
   </div>
   <div class="feature">
     <h3>Internationalization</h3>
-    <p>20+ languages supported with runtime locale switching</p>
+    <p>20+ languages supported via vue-i18n</p>
   </div>
   <div class="feature">
     <h3>Dark Theme</h3>
@@ -63,7 +63,7 @@ const handleEditorReady = (options) => {
 ```
 
 ::: tip Peer Dependencies
-Tiptapify requires **Vue 3.x**, **Vuetify 3.x or 4.x**, and **@mdi/js** as peer dependencies. See the [Installation guide](/guide/installation) for the full setup.
+Tiptapify requires **Vue 3.x**, **Vuetify 3.x or 4.x**, **vue-i18n 11+**, and **@mdi/js** as peer dependencies. See the [Installation guide](/guide/installation) for the full setup.
 :::
 
 ## License

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "vue": "^3.5.14",
-    "vuetify": "^3.12.3"
+    "vuetify": "^3.12.3",
+    "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
     "@mdi/js": "^7.4.47",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       vue:
         specifier: ^3.5.14
         version: 3.5.30
+      vue-i18n:
+        specifier: ^11.4.4
+        version: 11.4.4(vue@3.5.30)
       vuetify:
         specifier: ^3.12.3
         version: 3.12.3(vue@3.5.30)
@@ -217,6 +220,22 @@ packages:
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@intlify/core-base@11.4.4':
+    resolution: {integrity: sha512-w/vItlylrAmhebkIbVl5YY8XMCtj8Mb2g70ttxktMYuf5AuRahgEHL2iLgLIsZBIbTSgs4hkUo7ucCL0uTJvOg==}
+    engines: {node: '>= 22'}
+
+  '@intlify/devtools-types@11.4.4':
+    resolution: {integrity: sha512-PcBLmGmDQsTSVV911P8upzpcLJO1CNVYi/IH6bGnLR2nA+0L963+kXN1ZrisTEnbtw2ewN6HMMSldqzjronA0Q==}
+    engines: {node: '>= 22'}
+
+  '@intlify/message-compiler@11.4.4':
+    resolution: {integrity: sha512-vn0OAV9pYkJlPPmgnsSm5eAG3mL0+9C/oaded2JY9jmxBbhmUXT3TcAUY8WRgLY9Hte7lkUJKpXrVlYjMXBD2w==}
+    engines: {node: '>= 22'}
+
+  '@intlify/shared@11.4.4':
+    resolution: {integrity: sha512-QRUCHqda1U6aR14FR0vvXD4+4gj6+fm0AhAozvSuRCw0fCvrmCugWpgiR4xH2NI6s8am6N9p5OhirplsX8ZS3g==}
+    engines: {node: '>= 22'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -523,6 +542,9 @@ packages:
 
   '@vue/compiler-ssr@3.5.30':
     resolution: {integrity: sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/devtools-api@8.1.2':
     resolution: {integrity: sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==}
@@ -1019,6 +1041,12 @@ packages:
       postcss:
         optional: true
 
+  vue-i18n@11.4.4:
+    resolution: {integrity: sha512-gIbXVSFQV4jcSJxfwdZ5zSZmZ+12CnX0K3vBkRSd6Zn+HSzCp+QwUgPwpD/uN0oKNKI9RzlUXPKVedEuMgNG0A==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue@3.5.30:
     resolution: {integrity: sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==}
     peerDependencies:
@@ -1151,6 +1179,24 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify/types@2.0.0': {}
+
+  '@intlify/core-base@11.4.4':
+    dependencies:
+      '@intlify/devtools-types': 11.4.4
+      '@intlify/message-compiler': 11.4.4
+      '@intlify/shared': 11.4.4
+
+  '@intlify/devtools-types@11.4.4':
+    dependencies:
+      '@intlify/core-base': 11.4.4
+      '@intlify/shared': 11.4.4
+
+  '@intlify/message-compiler@11.4.4':
+    dependencies:
+      '@intlify/shared': 11.4.4
+      source-map-js: 1.2.1
+
+  '@intlify/shared@11.4.4': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -1392,6 +1438,8 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.30
       '@vue/shared': 3.5.30
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/devtools-api@8.1.2':
     dependencies:
@@ -1907,6 +1955,14 @@ snapshots:
       - typescript
       - universal-cookie
       - yaml
+
+  vue-i18n@11.4.4(vue@3.5.30):
+    dependencies:
+      '@intlify/core-base': 11.4.4
+      '@intlify/devtools-types': 11.4.4
+      '@intlify/shared': 11.4.4
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.30
 
   vue@3.5.30:
     dependencies:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,6 @@
-import { Editor } from "@tiptap/vue-3";
-import {
-  Component,
-  ComponentOptionsMixin, ComponentProvideOptions,
-  ComputedOptions, Directive,
-  EmitsOptions,
-  ExtractDefaultPropTypes,
-  MethodOptions,
-  PublicProps, SlotsType
-} from "@vue/runtime-core";
+import { Editor as TiptapEditor } from '@tiptap/vue-3'
 import type { DefineComponent } from 'vue'
-import { toolbarSections } from "./src/types/toolbarTypes";
+import { toolbarSections } from './src/types/toolbarTypes'
 
 export interface TiptapifyProps {
   content: string|object
@@ -31,25 +22,36 @@ export interface TiptapifyProps {
 }
 
 export interface TiptapifyEmits {
-  [key: string]: ((...args: any[]) => any) | null
+  [key: string]: ((...args: never[]) => never) | null
   'editor-ready': (options: {
     getHTML: () => string
-    getJSON: () => any
-    editor: Editor
+    getJSON: () => never
+    editor: TiptapEditor
   }) => void
 }
 
-export declare const Tiptapify: DefineComponent<TiptapifyProps, {}, {}, {}, {}, {}, {}, TiptapifyEmits>
+export declare const Tiptapify: DefineComponent<
+  TiptapifyProps,
+  object,
+  object,
+  Record<string, never>,
+  Record<string, never>,
+  object,
+  object,
+  TiptapifyEmits
+>
 
 export interface TiptapifyOptions {
-  locale?: string
+  i18n?: string
 }
 
 declare const TiptapifyPlugin: {
-  install: (app: any, options?: TiptapifyOptions) => void
+  install: (app: never, options?: TiptapifyOptions) => void
 }
 
 export default TiptapifyPlugin
+
+export { TiptapEditor }
 
 declare module '@vue/runtime-core' {
   interface GlobalComponents {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiptapify",
   "types": "./index.d.ts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Tiptap3 editor with Vuetify3 menu implementation",
   "exports": {
     ".": {
@@ -64,6 +64,7 @@
   "repository": "https://github.com/IVoyt/tiptapify",
   "packageManager": "pnpm@10.33.4",
   "dependencies": {
+    "@mdi/js": "^7.4.47",
     "@tiptap/core": "^3.23.5",
     "@tiptap/extension-blockquote": "^3.23.5",
     "@tiptap/extension-bold": "^3.23.5",
@@ -106,13 +107,12 @@
     "emoji.json": "^16.0.0",
     "highlight.js": "^11.11.1",
     "linkifyjs": "^4.3.2",
-    "lowlight": "^3.3.0",
-    "vue-i18n": "^11.3.0"
+    "lowlight": "^3.3.0"
   },
   "peerDependencies": {
-    "@mdi/js": "^7.4.47",
     "vue": "^3.5.14",
-    "vuetify": "^3.8.5 || ^4.0.0"
+    "vuetify": "^3.8.5 || ^4.0.0",
+    "vue-i18n": "^11.3.0"
   },
   "devDependencies": {
     "@intlify/unplugin-vue-i18n": "^11.1.1",

--- a/src/components/Tiptapify.vue
+++ b/src/components/Tiptapify.vue
@@ -3,13 +3,13 @@
 import defaults from '@tiptapify/constants/defaults'
 import { itemsPropType, toolbarSections } from '@tiptapify/types/toolbarTypes'
 import { SlashCommandsConfig } from '@tiptapify/types/slashCommandsTypes'
-import { computed, onBeforeUnmount, PropType, provide, ref, ShallowRef, watch } from 'vue'
+import { computed, onBeforeUnmount, PropType, provide, ref, ShallowRef } from 'vue'
 import { default as Toolbar } from '@tiptapify/components/Toolbar/Index.vue'
 import { Editor, EditorContent } from '@tiptap/vue-3'
 import MenuBubble from '@tiptapify/components/MenuBubble.vue'
 import MenuFloating from '@tiptapify/components/MenuFloating.vue'
 
-import { useLocale } from '@tiptapify/i18n'
+import { useI18n } from 'vue-i18n'
 
 import { getTiptapEditor } from '@tiptapify/components/index'
 
@@ -38,7 +38,7 @@ const props = defineProps({
   interactiveStyles: { type: Boolean, default() { return true } },
 })
 
-const { t, setLocale } = useLocale(props.locale)
+const { t } = useI18n()
 
 const appTheme = useTheme()
 const currentTheme = ref(appTheme.global.name)
@@ -57,7 +57,6 @@ const editor: ShallowRef<Editor | undefined> = getTiptapEditor(
       editorInstance.interactiveStyles = props.interactiveStyles
       emit('editor-ready', {
         editor: editorInstance,
-        setLocale,
         getHTML: () => editorInstance.getHTML(),
         getJSON: () => editorInstance.getJSON(),
       })
@@ -67,13 +66,9 @@ const editor: ShallowRef<Editor | undefined> = getTiptapEditor(
 const emit = defineEmits(['update:modelValue', 'editor-ready', 'content-changed'])
 
 provide('tiptapifyEditor', editor)
-provide('tiptapifyI18n', { t, setLocale })
+provide('tiptapifyI18n', { t })
 
 editor.value?.chain().setFontFamily(props.defaultFontFamily).run()
-
-watch(() => props.locale, () => {
-  setLocale(props.locale)
-})
 
 onBeforeUnmount(() => {
   editor.value?.destroy()

--- a/src/extensions/components/format/underline/Button.vue
+++ b/src/extensions/components/format/underline/Button.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
 
 import * as mdi from '@mdi/js'
-import { Editor } from "@tiptap/vue-3";
-import BtnIcon from "@tiptapify/components/UI/BtnIcon.vue";
-import { inject, Ref } from "vue";
+import { Editor } from '@tiptap/vue-3'
+import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
+import { inject, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
 
@@ -19,14 +19,14 @@ const { t } = inject('tiptapifyI18n') as any
 
 <template>
   <VBtn
-      :color="editor.isActive('underline') ? 'primary' : ''"
-      :disabled="!editor.can().chain().focus().toggleUnderline().run()"
-      :variant="variantBtn"
-      @click="editor.commands.toggleUnderline()"
-      size="32"
+    :color="editor.isActive('underline') ? 'primary' : ''"
+    :disabled="!editor.can().chain().focus().toggleUnderline().run()"
+    :variant="variantBtn"
+    size="32"
+    @click="editor.commands.toggleUnderline()"
   >
     <VTooltip activator="parent">
-      {{ t('format.strike') }}
+      {{ t('format.underline') }}
     </VTooltip>
     <BtnIcon :icon="`mdiSvg:${mdi.mdiFormatUnderline}`" />
   </VBtn>

--- a/src/extensions/slash-commands.ts
+++ b/src/extensions/slash-commands.ts
@@ -3,7 +3,8 @@ import { Editor } from '@tiptap/core'
 import Suggestion from '@tiptap/suggestion'
 import { VueRenderer, posToDOMRect } from '@tiptap/vue-3'
 import { computePosition, flip, shift } from '@floating-ui/dom'
-import { useLocale } from '@tiptapify/i18n'
+// import { useLocale } from '@tiptapify/i18n'
+import { useI18n } from 'vue-i18n'
 import CommandsList from '@tiptapify/extensions/components/slashCommands/CommandsList.vue'
 import PickerDialog from '@tiptapify/extensions/components/slashCommands/PickerDialog.vue'
 import { PickerEventBus } from '@tiptapify/extensions/PickerEventBus'
@@ -99,7 +100,7 @@ export default Extension.create<SlashCommandsExtensionOptions>(
           editor.chain().focus().deleteRange(range).run()
           closePicker()
 
-          const { t } = useLocale()
+          const { t } = useI18n()
 
           pickerComponent = new VueRenderer(PickerDialog, {
             props: {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,35 +1,7 @@
-import { createI18n } from 'vue-i18n'
-import { ref, computed } from 'vue'
-
 const messages = Object.fromEntries(
   Object.entries(
     import.meta.glob<{ default: any }>('./locales/*.json', { eager: true }))
     .map(([key, value]) => [key.slice(10, -5), value.default]),
 )
 
-export function useLocale(initialLocale: string = 'en') {
-  const currentLocale = ref(initialLocale)
-
-  const i18n = createI18n({
-    legacy: false,
-    locale: currentLocale.value,
-    fallbackLocale: 'en',
-    messages
-  })
-
-  const { t, locale } = i18n.global
-
-  const setLocale = (newLocale: string) => {
-    if (messages[newLocale]) {
-      currentLocale.value = newLocale
-      locale.value = newLocale
-    }
-  }
-
-  return {
-    i18n,
-    t,
-    locale: computed(() => currentLocale.value),
-    setLocale
-  }
-}
+export { messages }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,33 @@
-import { Plugin } from 'vue';
-import Tiptapify from '@tiptapify/components/Tiptapify.vue';
-import TiptapifyDialog from '@tiptapify/components/UI/TiptapifyDialog.vue';
+import { Plugin } from 'vue'
+import Tiptapify from '@tiptapify/components/Tiptapify.vue'
+import TiptapifyDialog from '@tiptapify/components/UI/TiptapifyDialog.vue'
+
+import { Editor as TipTapEditor } from '@tiptap/vue-3'
+import { Node, mergeAttributes } from '@tiptap/core'
+
+import * as mdi from '@mdi/js'
+
+import { messages } from './i18n'
 
 interface PackageOptions {
-  locale?: string;
+  i18n?: any;
 }
 
 const TiptapifyPlugin: Plugin = {
   install(app, options: PackageOptions = {}) {
-    app.component('Tiptapify', Tiptapify);
-    app.component('TiptapifyDialog', TiptapifyDialog);
-  }
-};
+    app.component('Tiptapify', Tiptapify)
+    app.component('TiptapifyDialog', TiptapifyDialog)
 
-export { Tiptapify, TiptapifyDialog };
-export default TiptapifyPlugin;
+    const i18n = options.i18n
+    for (const locale of Object.keys(messages)) {
+      i18n.global.mergeLocaleMessage(locale, messages[locale])
+    }
+  }
+}
+
+export { Tiptapify, TiptapifyDialog }
+export default TiptapifyPlugin
+
+export { mdi }
+export { TipTapEditor }
+export { Node, mergeAttributes }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,16 +59,17 @@ export default defineConfig({
           ]
         })
       ],
-      external: ['vue', 'vuetify'],
+      external: ['vue', 'vue-i18n', 'vuetify'],
       output: {
-        exports: "named",
+        exports: 'named',
         globals: {
           vue: 'Vue',
-          vuetify: 'Vuetify'
+          vuetify: 'Vuetify',
+          'vue-i18n': 'vueI18n'
         },
         assetFileNames: (assetInfo) => {
-          if (assetInfo.name === 'style.css') return 'tiptapify.css';
-          return assetInfo.name;
+          if (assetInfo.name === 'style.css') return 'tiptapify.css'
+          return assetInfo.name
         }
       }
     },


### PR DESCRIPTION
- Remove internal useLocale() — consumers now pass their own vue-i18n instance via plugin options ({ i18n })
- Plugin auto-merges built-in locale messages into consumer's i18n
- Drop `locale` prop from <Tiptapify> component
- Export TiptapEditor, mdi, Node, mergeAttributes from package
- Clean up type declaration