### PR TITLE
0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.1.5
-- export TipTap `Mark`
-- reformat
+- reexport TipTap modules
+- refactor
 
 ### 0.1.4
 - add loading, loadingColor and loadingHeight properties

--- a/docs/.vitepress/theme/components/InteractiveEditor.vue
+++ b/docs/.vitepress/theme/components/InteractiveEditor.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { ref, onMounted, onUnmounted, PropType } from 'vue'
 import { useTheme } from 'vuetify'
 
-const props = defineProps({
-  height: { type: [Number,String], default() { return 400 }},
-  items: { type: Array<string>, default() { return [] }},
-  itemsExclude: { type: Boolean, default() { return false }},
-  toolbar: { type: Boolean, default() { return true }},
-  bubbleMenu: { type: Boolean, default() { return false }},
-  floatingMenu: { type: Boolean, default() { return false }},
-  slashCommands: { type: [Boolean,Array<string>], default() { return true }},
-  placeholder: { type: String, default() { return "Start typing..." }},
-  variantBtn: { type: String, default() { return "solo" }},
+defineProps({
+  height: { type: [Number,String], default() { return 400 } },
+  items: { type: Array<string>, default() { return [] } },
+  itemsExclude: { type: Boolean, default() { return false } },
+  toolbar: { type: Boolean, default() { return true } },
+  bubbleMenu: { type: Boolean, default() { return false } },
+  floatingMenu: { type: Boolean, default() { return false } },
+  slashCommands: { type: [Boolean,Array<string>], default() { return true } },
+  placeholder: { type: String, default() { return 'Start typing...' } },
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return 'solo' } },
 })
 
 const content = ref('')

--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -171,10 +171,10 @@ Border radius for the editor container. Accepts Vuetify radius values (`sm`, `md
 
 ### `variantBtn`
 
-- **Type:** `String`
+- **Type:** `variantBtnTypes`
 - **Default:** `'tonal'`
 
-Vuetify button variant for toolbar buttons. Options: `text`, `flat`, `elevated`, `tonal`, `outlined`, `plain`.
+Vuetify button variant for toolbar buttons. See [`variantBtnTypes`](/api/types#variantbtntypes).
 
 ```vue
 <Tiptapify variant-btn="outlined" />
@@ -182,10 +182,10 @@ Vuetify button variant for toolbar buttons. Options: `text`, `flat`, `elevated`,
 
 ### `variantField`
 
-- **Type:** `String`
+- **Type:** `variantFieldTypes`
 - **Default:** `'outlined'`
 
-Vuetify variant for toolbar dropdown fields (font family, size, color).
+Vuetify variant for toolbar dropdown fields. See [`variantFieldTypes`](/api/types#variantfieldtypes).
 
 ```vue
 <Tiptapify variant-field="filled" />
@@ -254,7 +254,7 @@ Fired when the editor instance is ready.
 
 ```typescript
 interface EditorReadyPayload {
-  editor: TiptapEditor  // Raw Tiptap Editor instance
+  editor: TiptapifyEditor  // Tiptapify Editor instance
   getHTML: () => string  // Get current HTML content
   getJSON: () => object  // Get current JSON content
 }

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,5 +1,31 @@
 # Types
 
+## TiptapifyEditor
+
+Extended Tiptap Editor class with additional properties.
+
+```typescript
+declare class TiptapifyEditor extends Editor {
+  interactiveStyles: boolean | undefined
+}
+```
+
+## variantBtnTypes
+
+Defines valid values for the `variantBtn` prop across all toolbar button components.
+
+```typescript
+type variantBtnTypes = 'outlined' | 'plain' | 'flat' | 'text' | 'elevated' | 'tonal' | undefined
+```
+
+## variantFieldTypes
+
+Defines valid values for the `variantField` prop across toolbar dropdown fields.
+
+```typescript
+type variantFieldTypes = 'outlined' | 'plain' | 'filled' | 'solo' | 'solo-filled' | 'solo-inverted' | 'underlined' | undefined
+```
+
 ## ToolbarSectionsEnum
 
 ```typescript
@@ -75,9 +101,9 @@ Emitted via the `editor-ready` event.
 
 ```typescript
 interface EditorReadyPayload {
-  editor: Editor        // Tiptap Editor instance
-  getHTML: () => string  // Returns current HTML
-  getJSON: () => object  // Returns current JSON
+  editor: TiptapifyEditor  // Tiptapify Editor instance
+  getHTML: () => string     // Returns current HTML
+  getJSON: () => object     // Returns current JSON
 }
 ```
 
@@ -100,4 +126,48 @@ Options passed when installing the plugin.
 interface TiptapifyOptions {
   i18n: I18n  // vue-i18n instance
 }
+```
+
+## Re-exports
+
+The following utilities are re-exported from `@tiptap/core` for convenience when building custom extensions:
+
+| Export            | Kind     | Source          |
+|-------------------|----------|-----------------|
+| `Node`            | Class    | `@tiptap/core`  |
+| `Mark`            | Class    | `@tiptap/core`  |
+| `mergeAttributes` | Function | `@tiptap/core`  |
+| `markInputRule`   | Function | `@tiptap/core`  |
+| `markPasteRule`   | Function | `@tiptap/core`  |
+| `CommandProps`    | Type     | `@tiptap/core`  |
+| `InputRuleMatch`  | Type     | `@tiptap/core`  |
+| `PasteRuleMatch`  | Type     | `@tiptap/core`  |
+
+```typescript
+import { Node, Mark, mergeAttributes, markInputRule, markPasteRule } from 'tiptapify'
+import type { CommandProps, InputRuleMatch, PasteRuleMatch } from 'tiptapify'
+```
+
+### `mdi`
+
+Material Design Icons from `@mdi/js` are re-exported for toolbar icon customization.
+
+```typescript
+import { mdi } from 'tiptapify'
+```
+
+### `TipTapEditor`
+
+The underlying `@tiptap/vue-3` Editor class.
+
+```typescript
+import { TipTapEditor } from 'tiptapify'
+```
+
+### `Tiptapify` / `TiptapifyDialog`
+
+The editor and dialog components are available as named exports for direct use.
+
+```typescript
+import { Tiptapify, TiptapifyDialog } from 'tiptapify'
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,45 +1,66 @@
 import { Editor as TiptapEditor } from '@tiptap/vue-3'
-import type { DefineComponent } from 'vue'
-import { toolbarSections } from './src/types/toolbarTypes'
+import {
+  Extension,
+  ExtendableConfig,
+  InputRule,
+  PasteRule,
+  Node,
+  Mark,
+  markInputRule,
+  markPasteRule,
+  mergeAttributes
+} from '@tiptap/core'
+import type {
+  AnyExtension,
+  CanCommands,
+  ChainedCommands,
+  Command,
+  CommandProps,
+  Commands,
+  Content,
+  EditorOptions,
+  EditorEvents,
+  Extensions,
+  ExtensionConfig,
+  InputRuleMatch,
+  JSONContent,
+  MarkConfig,
+  NodeConfig,
+  PasteRuleMatch,
+  Range,
+  RawCommands,
+  SingleCommands,
+} from '@tiptap/core'
 
-export interface TiptapifyProps {
-  content: string|object
-  variantBtn: string
-  variantField: string
-  toolbar: boolean
-  items: [string]
-  itemsExclude: boolean
-  bubbleMenu: boolean
-  floatingMenu: boolean
-  slashCommands: boolean
-  placeholder: string
-  showWordsCount: boolean
-  showCharactersCount: boolean
-  defaultFontFamily: string
-  fontMeasure: string
-  rounded: string
-  customExtensions: toolbarSections
-}
+import '@tiptap/extension-text-style'
+import '@tiptap/extension-list'
+import '@tiptap/extensions'
+import '@tiptap/extension-document'
+import '@tiptap/extension-text'
+import '@tiptap/extension-paragraph'
+import '@tiptap/extension-heading'
+import '@tiptap/extension-bold'
+import '@tiptap/extension-italic'
+import '@tiptap/extension-strike'
+import '@tiptap/extension-code'
+import '@tiptap/extension-blockquote'
+import '@tiptap/extension-hard-break'
+import '@tiptap/extension-horizontal-rule'
+import '@tiptap/extension-typography'
+import '@tiptap/extension-highlight'
+import '@tiptap/extension-image'
+import '@tiptap/extension-youtube'
+import '@tiptap/extension-superscript'
+import '@tiptap/extension-subscript'
+import '@tiptap/extension-text-align'
+import '@tiptap/extension-underline'
+import '@tiptap/extension-table'
+import '@tiptap/extension-code-block-lowlight'
+import '@tiptap/extension-invisible-characters'
 
-export interface TiptapifyEmits {
-  [key: string]: ((...args: never[]) => never) | null
-  'editor-ready': (options: {
-    getHTML: () => string
-    getJSON: () => never
-    editor: TiptapEditor
-  }) => void
-}
-
-export declare const Tiptapify: DefineComponent<
-  TiptapifyProps,
-  object,
-  object,
-  Record<string, never>,
-  Record<string, never>,
-  object,
-  object,
-  TiptapifyEmits
->
+import Tiptapify from './src/components/Tiptapify.vue'
+import TiptapifyDialog from './src/components/UI/TiptapifyDialog.vue'
+import * as mdi from '@mdi/js'
 
 export interface TiptapifyOptions {
   i18n?: string
@@ -51,7 +72,43 @@ declare const TiptapifyPlugin: {
 
 export default TiptapifyPlugin
 
-export { TiptapEditor }
+export {
+  mdi,
+  Tiptapify,
+  TiptapifyDialog,
+  TiptapEditor,
+  Extension,
+  ExtendableConfig,
+  InputRule,
+  Mark,
+  mergeAttributes,
+  markInputRule,
+  markPasteRule,
+  Node,
+  PasteRule,
+}
+
+export type {
+  AnyExtension,
+  CanCommands,
+  ChainedCommands,
+  Command,
+  CommandProps,
+  Commands,
+  Content,
+  EditorOptions,
+  EditorEvents,
+  Extensions,
+  ExtensionConfig,
+  InputRuleMatch,
+  JSONContent,
+  MarkConfig,
+  NodeConfig,
+  PasteRuleMatch,
+  Range,
+  RawCommands,
+  SingleCommands,
+}
 
 declare module '@vue/runtime-core' {
   interface GlobalComponents {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { Editor } from '@tiptap/vue-3'
 import { computed, inject, ref, Ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 const props = defineProps({
   showWordsCount: { type: Boolean, default: true },
   showCharactersCount: { type: Boolean, default: true },
 })
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 

--- a/src/components/Tiptapify.vue
+++ b/src/components/Tiptapify.vue
@@ -6,6 +6,7 @@ import { SlashCommandsConfig } from '@tiptapify/types/slashCommandsTypes'
 import { computed, onBeforeUnmount, PropType, provide, ref, ShallowRef } from 'vue'
 import { default as Toolbar } from '@tiptapify/components/Toolbar/Index.vue'
 import { Editor, EditorContent } from '@tiptap/vue-3'
+import { TiptapifyEditor, variantBtnTypes, variantFieldTypes } from '@tiptapify/types/editor'
 import MenuBubble from '@tiptapify/components/MenuBubble.vue'
 import MenuFloating from '@tiptapify/components/MenuFloating.vue'
 
@@ -18,12 +19,12 @@ import { useTheme } from 'vuetify/framework'
 
 const props = defineProps({
   locale: { type: String, default () { return 'en' } },
-  content: String|Object,
-  height: { type: [Number,String], default () { return null } },
-  variantBtn: { type: String, default () { return defaults.variantBtn } },
-  variantField: { type: String, default () { return defaults.variantField } },
+  content: { type: [String, Object] as PropType<string | Record<string, never>>, required: true },
+  height: { type: [Number, String], default () { return null } },
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
+  variantField: { type: String as PropType<variantFieldTypes>, default() { return defaults.variantField } },
   toolbar: { type: Boolean, default () { return true } },
-  items: { type: [Array, Object as PropType<itemsPropType>], default() { return [] } },
+  items: { type: [Array, Object] as PropType<itemsPropType>, default() { return [] } },
   itemsExclude: { type: Boolean, default() { return false } },
   bubbleMenu: { type: Boolean, default () { return true } },
   floatingMenu: { type: Boolean, default () { return true } },
@@ -58,8 +59,8 @@ const editor: ShallowRef<Editor | undefined> = getTiptapEditor(
     props.slashCommands,
     props.customExtensions,
     contentChanged,
-    (editorInstance) => {
-      editorInstance.interactiveStyles = props.interactiveStyles
+    (editorInstance: Editor) => {
+      (<TiptapifyEditor>editorInstance).interactiveStyles = props.interactiveStyles
       emit('editor-ready', {
         editor: editorInstance,
         getHTML: () => editorInstance.getHTML(),
@@ -74,6 +75,15 @@ provide('tiptapifyEditor', editor)
 provide('tiptapifyI18n', { t })
 
 editor.value?.chain().setFontFamily(props.defaultFontFamily).run()
+
+const computeResizableHeight = computed(() => {
+  let height = props.height
+  if (typeof height === 'string') {
+    height = parseInt(height)
+  }
+
+  return height > 0 ? `height: ${height}px` : ''
+})
 
 onBeforeUnmount(() => {
   editor.value?.destroy()
@@ -99,7 +109,7 @@ onBeforeUnmount(() => {
 
       <VProgressLinear v-model="loadingProgress" :color="loadingColor" :height="loadingHeight" :indeterminate="loading" />
 
-      <div class="pa-2 tiptapify-container resizable" :style="`${height > 0 ? `height: ${height}px` : ''}`">
+      <div class="pa-2 tiptapify-container resizable" :style="computeResizableHeight">
         <MenuFloating v-if="floatingMenu" :variant="variantBtn" :theme="currentTheme" />
 
         <MenuBubble v-if="bubbleMenu" :variant="variantBtn" :theme="currentTheme" />

--- a/src/components/Tiptapify.vue
+++ b/src/components/Tiptapify.vue
@@ -180,7 +180,7 @@ onBeforeUnmount(() => {
     font-size: .875rem;
     font-weight: 500;
     line-height: 1.15;
-    margin: none;
+    margin: unset;
     padding: .375rem .625rem;
     transition: all .2s cubic-bezier(.65,.05,.36,1);
   }

--- a/src/components/Toolbar/Index.vue
+++ b/src/components/Toolbar/Index.vue
@@ -6,12 +6,12 @@ import { variantBtnTypes, variantFieldTypes } from '@tiptapify/types/editor'
 import { computed, inject, PropType, Ref } from 'vue'
 import { itemsPropType, toolbarSections } from '@tiptapify/types/toolbarTypes'
 
-import { default as items, availableItems } from '@tiptapify/components/Toolbar/items'
+import { default as toolbarItemsGroups, availableItems } from '@tiptapify/components/Toolbar/items'
 
 const props = defineProps({
   variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
   variantField: { type: String as PropType<variantFieldTypes>, default() { return defaults.variantField } },
-  items: { type: [Array, Object as PropType<itemsPropType>], default() { return [] } },
+  items: { type: [Array, Object] as PropType<itemsPropType>, default() { return [] } },
   itemsExclude: { type: Boolean, default() { return false } },
   fontMeasure: { type: String, default () { return 'px' } },
   customFonts: { type: Array<string>, default () { return [] } },
@@ -25,20 +25,23 @@ const props = defineProps({
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
 const propsItems = computed(() => props.items)
-const propsItemsIsList = computed(() => Array.isArray(propsItems.value))
 const propsItemsExclude = computed(() => props.itemsExclude)
 
 // this prevents from overriding the default items
-let toolbarItems = [...Object.values(items)]
+let toolbarItems = [...Object.values(toolbarItemsGroups)]
 const availableItemsKeys = Object.keys(availableItems)
 
 type toolbarItemsType = { [key: string]: { section: string, group: boolean, components: any[] } }
-propsItemsExclude.value ? prepareExcludeToolbarItems() : prepareToolbarItems()
+if (propsItemsExclude.value) {
+  prepareExcludeToolbarItems()
+} else {
+  prepareToolbarItems()
+}
 
 function prepareToolbarItems() {
   const _toolbarItems: toolbarItemsType = {}
 
-  if (!propsItemsIsList.value) {
+  if (!Array.isArray(propsItems.value)) {
     for (const propsItemSection in propsItems.value as itemsPropType) {
       if (propsItems.value[propsItemSection].length === 0) {
         continue
@@ -95,15 +98,15 @@ function prepareExcludeToolbarItems() {
   toolbarItems = Object.values(_toolbarItems)
 }
 
-function addToolbarItem(_toolbarItems: toolbarItemsType, itemsList: any, itemTitle: string, group: boolean|null = null): boolean {
+function addToolbarItem(_toolbarItems: toolbarItemsType, itemsList: Array<any>, itemTitle: string, group: boolean|null = null): boolean {
   const item = itemTitle.split(':')
   const _itemTitle = item[0]
   const _itemOptions = item[1] ? item[1].split(',') : []
 
   const itemSection = availableItems[_itemTitle]
-  const section = items[itemSection]
+  const section = toolbarItemsGroups[itemSection]
 
-  const component = section?.components.find((component: any) => component.name === _itemTitle)
+  const component = section?.components.find((component: { name: string }) => component.name === _itemTitle)
 
   let itemExists = itemsList.includes(itemTitle)
   itemExists = propsItemsExclude.value ? itemExists : !itemExists
@@ -112,7 +115,7 @@ function addToolbarItem(_toolbarItems: toolbarItemsType, itemsList: any, itemTit
   }
 
   if (group === null) {
-    group = section.group
+    group = section.group ?? true
   }
 
   if (typeof _toolbarItems[itemSection] === 'undefined') {
@@ -124,7 +127,7 @@ function addToolbarItem(_toolbarItems: toolbarItemsType, itemsList: any, itemTit
   }
 
   if (_itemTitle === 'heading' && _itemOptions.length > 0) {
-    const paragraphIndex = _itemOptions.findIndex((item: any) => item === 'p')
+    const paragraphIndex = _itemOptions.findIndex((item: string) => item === 'p')
     const withParagraph = paragraphIndex > -1
     if (withParagraph) {
       _itemOptions.splice(paragraphIndex, 1)
@@ -132,7 +135,7 @@ function addToolbarItem(_toolbarItems: toolbarItemsType, itemsList: any, itemTit
 
     component.props = {
       withParagraph,
-      customHeadingLevels: _itemOptions,
+      customHeadingLevels: _itemOptions.map((item: string) => parseInt(item)),
     }
   }
 

--- a/src/components/Toolbar/Index.vue
+++ b/src/components/Toolbar/Index.vue
@@ -2,14 +2,15 @@
 import { Editor } from '@tiptap/vue-3'
 import Items from '@tiptapify/components/Toolbar/Items.vue'
 import defaults from '@tiptapify/constants/defaults'
+import { variantBtnTypes, variantFieldTypes } from '@tiptapify/types/editor'
 import { computed, inject, PropType, Ref } from 'vue'
 import { itemsPropType, toolbarSections } from '@tiptapify/types/toolbarTypes'
 
 import { default as items, availableItems } from '@tiptapify/components/Toolbar/items'
 
 const props = defineProps({
-  variantBtn: { type: String, default () { return defaults.variantBtn } },
-  variantField: { type: String, default () { return defaults.variantField } },
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
+  variantField: { type: String as PropType<variantFieldTypes>, default() { return defaults.variantField } },
   items: { type: [Array, Object as PropType<itemsPropType>], default() { return [] } },
   itemsExclude: { type: Boolean, default() { return false } },
   fontMeasure: { type: String, default () { return 'px' } },

--- a/src/components/Toolbar/Items.vue
+++ b/src/components/Toolbar/Items.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 
 import defaults from '@tiptapify/constants/defaults'
+import { variantBtnTypes } from '@tiptapify/types/editor'
 import { PropType } from 'vue'
 
 import { toolbarSections } from '@tiptapify/types/toolbarTypes'
 
 defineProps({
-  variantBtn: { type: String, default () { return defaults.variantBtn } },
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
   items: { type: Array as PropType<toolbarSections>, default() { return {} } },
 })
 

--- a/src/components/UI/TiptapifyDialog.vue
+++ b/src/components/UI/TiptapifyDialog.vue
@@ -2,6 +2,7 @@
 
 import * as mdi from '@mdi/js'
 import { inject, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 const props = defineProps({
   module: String,
@@ -10,20 +11,20 @@ const props = defineProps({
   maxWidth: { type: Number, default () { return 800 } },
 })
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 defineExpose({ open, close })
 const emits = defineEmits(['closeDialog'])
 
-const dialog = ref<boolean>(false)
+const showDialog = ref<boolean>(false)
 const movableHandler = ref(null)
 
 function open() {
-  dialog.value = true
+  showDialog.value = true
 }
 
 function close() {
-  dialog.value = false
+  showDialog.value = false
 }
 
 function emitClose() {
@@ -89,26 +90,26 @@ function dragElement(trigger: HTMLElement, container: HTMLElement) {
   }
 }
 
-watch(() => dialog.value, async () => {
+watch(() => showDialog.value, async () => {
   await nextTick()
 
   if (!movableHandler.value) {
     return
   }
 
-  if (dialog.value && !props.fullscreen) {
+  if (showDialog.value && !props.fullscreen) {
     dragElement(movableHandler.value.$el as HTMLElement, movableHandler.value.$el.parentNode as HTMLElement)
   }
 })
 
 function resizeListener() {
-  if (!dialog.value) {
+  if (!showDialog.value) {
     return
   }
 
   const dialogCoordinates = movableHandler.value.$el.parentNode.getBoundingClientRect()
 
-  function checkBoundLeftTop(type) {
+  function checkBoundLeftTop(type: string) {
     if (dialogCoordinates[type] < 0) {
       const dialogOffset = movableHandler.value.$el.parentNode.style[type]
       const newOffset = parseInt(dialogOffset) - dialogCoordinates[type]
@@ -139,7 +140,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <VDialog v-model="dialog" :max-width="maxWidth" :fullscreen="fullscreen" @click:outside="emitClose">
+  <VDialog v-model="showDialog" :max-width="maxWidth" :fullscreen="fullscreen" @click:outside="emitClose">
     <VCard>
       <VCardTitle
         ref="movableHandler"

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,7 +5,7 @@ import { SlashCommandsConfig } from '@tiptapify/types/slashCommandsTypes'
 import { ShallowRef } from 'vue'
 
 export function getTiptapEditor (
-  content: any,
+  content: string|object,
   placeholder: string,
   slashCommands: SlashCommandsConfig = true,
   customExtensions: toolbarSections,

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -1,4 +1,5 @@
-import { ref } from 'vue'
+import { Level } from '@tiptap/extension-heading'
+import { Ref, ref } from 'vue'
 
 export const defaultFontSize = 12
 export const fontSizes = [6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 32, 48, 64, 96]
@@ -6,8 +7,8 @@ export const fontSizes = [6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 32, 48, 64, 96]
 export const defaultLineHeight = 1
 export const lineHeights = [1, 1.5, 2, 3, 4]
 
-export const headingLevels = ref([1, 2, 3, 4, 5, 6])
-export function setHeadingLevels(customHeadingLevels: number[]) {
+export const headingLevels: Ref<Level[]> = ref([1, 2, 3, 4, 5, 6])
+export function setHeadingLevels(customHeadingLevels: Level[]) {
   if (customHeadingLevels.length) {
     customHeadingLevels.forEach(level => {
       if (level < 1 || level > 6) {

--- a/src/extensions/components/actions/redo/Button.vue
+++ b/src/extensions/components/actions/redo/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/actions/undo/Button.vue
+++ b/src/extensions/components/actions/undo/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/alignment/center/Button.vue
+++ b/src/extensions/components/alignment/center/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/alignment/justify/Button.vue
+++ b/src/extensions/components/alignment/justify/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/alignment/left/Button.vue
+++ b/src/extensions/components/alignment/left/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/alignment/right/Button.vue
+++ b/src/extensions/components/alignment/right/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/format/bold/Button.vue
+++ b/src/extensions/components/format/bold/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/format/italic/Button.vue
+++ b/src/extensions/components/format/italic/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/format/strike/Button.vue
+++ b/src/extensions/components/format/strike/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/format/underline/Button.vue
+++ b/src/extensions/components/format/underline/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/formatExtra/code/Button.vue
+++ b/src/extensions/components/formatExtra/code/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/formatExtra/codeBlock/Button.vue
+++ b/src/extensions/components/formatExtra/codeBlock/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/formatExtra/quote/Button.vue
+++ b/src/extensions/components/formatExtra/quote/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/formatExtra/sub/Button.vue
+++ b/src/extensions/components/formatExtra/sub/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/formatExtra/sup/Button.vue
+++ b/src/extensions/components/formatExtra/sup/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/list/bullet/Button.vue
+++ b/src/extensions/components/list/bullet/Button.vue
@@ -3,12 +3,14 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { computed, inject, ref, Ref, watch } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { computed, inject, PropType, ref, Ref, watch } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 const props = defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn },
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
   withDisc: { type: Boolean, default: true },
   withCircle: { type: Boolean, default: true },
   withSquare: { type: Boolean, default: true }
@@ -16,7 +18,7 @@ const props = defineProps({
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const disc = computed(() => props.withDisc)
 const circle = computed(() => props.withCircle)

--- a/src/extensions/components/list/indent/Button.vue
+++ b/src/extensions/components/list/indent/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/list/numbered/Button.vue
+++ b/src/extensions/components/list/numbered/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { computed, inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { computed, inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const buttonDisabled = computed(() => {
   return !editor.value.can().chain().focus().toggleBulletList().run() &&

--- a/src/extensions/components/list/outdent/Button.vue
+++ b/src/extensions/components/list/outdent/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/list/task/Button.vue
+++ b/src/extensions/components/list/task/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { computed, inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { computed, inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const buttonDisabled = computed(() => {
   return !editor.value.can().chain().focus().toggleBulletList().run() &&

--- a/src/extensions/components/media/charmap/Button.vue
+++ b/src/extensions/components/media/charmap/Button.vue
@@ -1,14 +1,17 @@
 <script lang="ts" setup>
 import * as mdi from '@mdi/js'
-import { inject, Ref } from 'vue'
+import { Editor } from '@tiptap/core'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 import CharmapPicker from './Picker.vue'
 
 defineProps({
-  variantBtn: { type: String, default: 'flat' },
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return 'flat' } },
 })
 
-const editor = inject('tiptapifyEditor') as Ref<any>
-const { t } = inject('tiptapifyI18n') as any
+const editor = inject('tiptapifyEditor') as Ref<Editor>
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 </script>
 
 <template>

--- a/src/extensions/components/media/emoji/Button.vue
+++ b/src/extensions/components/media/emoji/Button.vue
@@ -1,17 +1,19 @@
 <script lang="ts" setup>
 import * as mdi from '@mdi/js'
-import { inject, Ref } from 'vue'
+import { TiptapifyEditor, variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
+import { ComposerTranslation } from 'vue-i18n'
 import EmojiPicker from './Picker.vue'
 import defaults from '@tiptapify/constants/defaults'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
-const editor = inject('tiptapifyEditor') as Ref<any>
+const editor = inject('tiptapifyEditor') as Ref<TiptapifyEditor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 </script>
 
 <template>

--- a/src/extensions/components/media/iframe/Button.vue
+++ b/src/extensions/components/media/iframe/Button.vue
@@ -3,19 +3,21 @@
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import IframeDialog from '@tiptapify/extensions/components/media/iframe/IframeDialog.vue'
-import { inject, ref, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, ref, Ref, useTemplateRef } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
-const dialog = ref(null)
+const dialog = useTemplateRef('dialog')
 
 const icon = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M1 12h9.8L8.3 9.5l1.4-1.4l4.9 4.9l-4.9 4.9l-1.4-1.4l2.5-2.5H1zM21 2H3c-1.1 0-2 .9-2 2v6.1h2V6h18v14H3v-4H1v4c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2"/></svg>'
 </script>

--- a/src/extensions/components/media/iframe/IframeDialog.vue
+++ b/src/extensions/components/media/iframe/IframeDialog.vue
@@ -3,18 +3,20 @@
 import { Editor } from '@tiptap/vue-3'
 import TiptapifyDialog from '@tiptapify/components/UI/TiptapifyDialog.vue'
 import defaults from '@tiptapify/constants/defaults'
+import { variantBtnTypes, variantFieldTypes } from '@tiptapify/types/editor'
 
 import type { iframeOptions } from '@tiptapify/types/iframe'
 
-import { computed, inject, Ref, ref, watch } from 'vue'
+import { computed, inject, PropType, Ref, ref, useTemplateRef, watch } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default() { return defaults.variantBtn } },
-  variantField: { type: String, default() { return defaults.variantField } }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
+  variantField: { type: String as PropType<variantFieldTypes>, default() { return defaults.variantField } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const generateIframeAttrs = (): iframeOptions => ({
   src: '',
@@ -28,7 +30,7 @@ const generateIframeAttrs = (): iframeOptions => ({
 const attrs = ref(generateIframeAttrs())
 const srcInvalid = ref(false)
 
-const dialog = ref(null)
+const dialog = useTemplateRef('dialog')
 
 const isDisabled = computed(() => {
   const { src } = attrs.value

--- a/src/extensions/components/media/image/Button.vue
+++ b/src/extensions/components/media/image/Button.vue
@@ -4,17 +4,19 @@ import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import ImageDialog from '@tiptapify/extensions/components/media/image/ImageDialog.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/media/image/ImageDialog.vue
+++ b/src/extensions/components/media/image/ImageDialog.vue
@@ -4,16 +4,18 @@ import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import TiptapifyDialog from '@tiptapify/components/UI/TiptapifyDialog.vue'
 import defaults from '@tiptapify/constants/defaults'
+import { variantBtnTypes, variantFieldTypes } from '@tiptapify/types/editor'
 
-import { computed, inject, onMounted, onUnmounted, Ref, ref } from 'vue'
+import { computed, inject, onMounted, onUnmounted, PropType, Ref, ref, useTemplateRef } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default() { return defaults.variantBtn } },
-  variantField: { type: String, default() { return defaults.variantField } }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
+  variantField: { type: String as PropType<variantFieldTypes>, default() { return defaults.variantField } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const generateImageAttrs = () => ({
   src: '',
@@ -25,7 +27,7 @@ const generateImageAttrs = () => ({
 
 const attrs = ref(generateImageAttrs())
 
-const dialog = ref(null)
+const dialog = useTemplateRef('dialog')
 
 const isDisabled = computed(() => {
   const { src } = attrs.value
@@ -33,7 +35,7 @@ const isDisabled = computed(() => {
 })
 
 const keepRatio = ref(true)
-const ratio = ref(null)
+const ratio: Ref<string> = ref('')
 function setRatio(force: boolean = false) {
   if (!keepRatio.value && !force) {
     return
@@ -60,7 +62,7 @@ function updateSizeRatio(dim: string) {
 
   const target = source === 'width' ? 'height' : 'width'
 
-  attrs.value[target] = parseFloat(sizeRatio).toFixed(0)
+  attrs.value[target] = parseFloat(String(sizeRatio)).toFixed(0)
 }
 
 function apply() {
@@ -97,7 +99,7 @@ function clear() {
 }
 
 function close() {
-  dialog.value.close()
+  dialog.value?.close()
 
   attrs.value = generateImageAttrs()
   ratio.value = null
@@ -114,7 +116,7 @@ const showTiptapifyImage = (event: CustomEvent) => {
   attrs.value.width = event.detail.image?.width
   attrs.value.height = event.detail.image?.height
 
-  dialog.value.open()
+  dialog.value?.open()
 }
 
 onMounted(() => {

--- a/src/extensions/components/media/link/Button.vue
+++ b/src/extensions/components/media/link/Button.vue
@@ -1,20 +1,21 @@
 <script lang="ts" setup>
 
 import * as mdi from '@mdi/js'
-import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import LinkDialog from '@tiptapify/extensions/components/media/link/LinkDialog.vue'
-import { computed, inject, Ref } from 'vue'
+import { TiptapifyEditor, variantBtnTypes } from '@tiptapify/types/editor'
+import { computed, inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
-const editor = inject('tiptapifyEditor') as Ref<Editor>
+const editor = inject('tiptapifyEditor') as Ref<TiptapifyEditor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const icon = computed(() => editor.value.isActive('tiptapifyLink') ? `mdiSvg:${mdi.mdiLinkOff}` : `mdiSvg:${mdi.mdiLink}`)
 

--- a/src/extensions/components/media/link/LinkDialog.vue
+++ b/src/extensions/components/media/link/LinkDialog.vue
@@ -2,18 +2,20 @@
 
 import { Editor } from '@tiptap/vue-3'
 import defaults from '@tiptapify/constants/defaults'
+import { variantBtnTypes, variantFieldTypes } from '@tiptapify/types/editor'
 
-import { computed, inject, onMounted, onUnmounted, Ref, ref, watch } from 'vue'
+import { computed, inject, onMounted, onUnmounted, PropType, Ref, ref, useTemplateRef, watch } from 'vue'
 
 import TiptapifyDialog from '@tiptapify/components/UI/TiptapifyDialog.vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default() { return defaults.variantBtn } },
-  variantField: { type: String, default() { return 'outlined' } }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
+  variantField: { type: String as PropType<variantFieldTypes>, default() { return 'outlined' } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const generateLinkAttrs = () => ({
   href: '',
@@ -32,7 +34,7 @@ const targetAttrs = computed(() => [
 const attrs = ref(generateLinkAttrs())
 const hrefInvalid = ref(false)
 
-const dialog = ref(null)
+const dialog = useTemplateRef('dialog')
 
 const isDisabled = computed(() => {
   const { href } = attrs.value

--- a/src/extensions/components/media/link/index.ts
+++ b/src/extensions/components/media/link/index.ts
@@ -1,23 +1,22 @@
+import { CommandProps } from '@tiptap/core'
 import Link from '@tiptap/extension-link'
-
-const name: string = 'link'
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
-    link: {
+    tiptapify_link: {
       showLink: () => ReturnType
     }
   }
 }
 
 export const TiptapifyLink = Link.extend({
-  name,
+  name: 'tiptapify_link',
 
   addCommands() {
     return {
       ...this.parent?.(),
-      showLink: () => ({ editor }) => {
-        const event = new CustomEvent(`tiptapify-show-${name}`, {
+      showLink: () => ({ editor }: CommandProps) => {
+        const event = new CustomEvent('tiptapify-show-link', {
           detail: {
             link: editor.getAttributes('link'),
             editorId: editor.instanceId

--- a/src/extensions/components/media/table/Button.vue
+++ b/src/extensions/components/media/table/Button.vue
@@ -6,17 +6,19 @@ import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import ColumnActions from '@tiptapify/extensions/components/media/table/ColumnActions.vue'
 import RowActions from '@tiptapify/extensions/components/media/table/RowActions.vue'
 import TableBuilder from '@tiptapify/extensions/components/media/table/TableBuilder.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 
 const rowActionsDisabled = () => {

--- a/src/extensions/components/media/table/ColumnActions.vue
+++ b/src/extensions/components/media/table/ColumnActions.vue
@@ -4,10 +4,11 @@ import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import { inject, Ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const columnCanAddBefore = () => {
   return editor.value.can().chain().focus().addColumnBefore().run()

--- a/src/extensions/components/media/table/RowActions.vue
+++ b/src/extensions/components/media/table/RowActions.vue
@@ -4,10 +4,11 @@ import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import { inject, Ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const rowCanAddBefore = () => {
   return editor.value.can().chain().focus().addRowBefore().run()

--- a/src/extensions/components/media/table/TableBuilder.vue
+++ b/src/extensions/components/media/table/TableBuilder.vue
@@ -3,8 +3,9 @@
 import { Editor } from '@tiptap/vue-3'
 
 import { inject, Ref, ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 defineExpose({ open })
 

--- a/src/extensions/components/media/video/Button.vue
+++ b/src/extensions/components/media/video/Button.vue
@@ -3,17 +3,19 @@
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import VideoDialog from '@tiptapify/extensions/components/media/video/VideoDialog.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const icon = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M4 6H2v14a2 2 0 0 0 2 2h14v-2H4zm16-4H8a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2m-8 12.5v-9l6 4.5z"/></svg>'
 </script>

--- a/src/extensions/components/media/video/VideoDialog.vue
+++ b/src/extensions/components/media/video/VideoDialog.vue
@@ -3,16 +3,18 @@
 import { Editor } from '@tiptap/vue-3'
 import TiptapifyDialog from '@tiptapify/components/UI/TiptapifyDialog.vue'
 import defaults from '@tiptapify/constants/defaults'
+import { variantBtnTypes, variantFieldTypes } from '@tiptapify/types/editor'
 
-import { computed, inject, onMounted, onUnmounted, Ref, ref } from 'vue'
+import { computed, inject, onMounted, onUnmounted, PropType, Ref, ref, useTemplateRef } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default() { return defaults.variantBtn } },
-  variantField: { type: String, default() { return defaults.variantField } }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
+  variantField: { type: String as PropType<variantFieldTypes>, default() { return defaults.variantField } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 type videoAttrs = {
   src: string,
@@ -27,7 +29,7 @@ const generateVideoAttrs = () => ({
 
 const attrs = ref(generateVideoAttrs())
 
-const dialog = ref(null)
+const dialog = useTemplateRef('dialog')
 
 const isDisabled = computed(() => {
   const { src } = attrs.value

--- a/src/extensions/components/misc/break/Button.vue
+++ b/src/extensions/components/misc/break/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/misc/formatClear/Button.vue
+++ b/src/extensions/components/misc/formatClear/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/misc/fullscreen/Button.vue
+++ b/src/extensions/components/misc/fullscreen/Button.vue
@@ -3,28 +3,30 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, nextTick, ref, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, nextTick, PropType, ref, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
-const dialog = ref(false)
+const showDialog = ref(false)
 
 async function dialogOpen() {
-  dialog.value = true
+  showDialog.value = true
 
   await changeEditorContainer('tiptapify-editor', 'tiptapify-editor-fullscreen')
 }
 
 async function dialogClose() {
-  dialog.value = false
+  showDialog.value = false
 
   await changeEditorContainer('tiptapify-editor-fullscreen', 'tiptapify-editor')
 }
@@ -44,17 +46,17 @@ async function changeEditorContainer(source: string, target: string) {
 <template>
   <VBtn
     size="32"
-    :color="dialog ? 'primary' : ''"
+    :color="showDialog ? 'primary' : ''"
     :variant="variantBtn"
-    @click="dialog ? dialogClose() : dialogOpen()"
+    @click="showDialog ? dialogClose() : dialogOpen()"
   >
     <VTooltip activator="parent">
       {{ t('misc.fullscreen') }}
     </VTooltip>
-    <BtnIcon :icon="dialog ? `mdiSvg:${mdi.mdiFullscreenExit}` : `mdiSvg:${mdi.mdiFullscreen}`" />
+    <BtnIcon :icon="showDialog ? `mdiSvg:${mdi.mdiFullscreenExit}` : `mdiSvg:${mdi.mdiFullscreen}`" />
   </VBtn>
 
-  <VDialog v-model="dialog" fullscreen @close="dialogClose()" @update:model-value="!dialog ? dialogClose() : ''">
+  <VDialog v-model="showDialog" fullscreen @close="dialogClose()" @update:model-value="!showDialog ? dialogClose() : ''">
     <VCard>
       <div :id="`tiptapify-editor-fullscreen-${editor?.instanceId}`" />
     </VCard>

--- a/src/extensions/components/misc/invisibleChar/Button.vue
+++ b/src/extensions/components/misc/invisibleChar/Button.vue
@@ -2,17 +2,19 @@
 
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><path fill="currentColor" d="M256 64L512 64C529.7 64 544 78.3 544 96C544 113.7 529.7 128 512 128L480 128L480 544C480 561.7 465.7 576 448 576C430.3 576 416 561.7 416 544L416 128L368 128L368 544C368 561.7 353.7 576 336 576C318.3 576 304 561.7 304 544L304 384L256 384C167.6 384 96 312.4 96 224C96 135.6 167.6 64 256 64z"/></svg>'
 

--- a/src/extensions/components/misc/line/Button.vue
+++ b/src/extensions/components/misc/line/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, onMounted, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 </script>
 

--- a/src/extensions/components/misc/preview/Button.vue
+++ b/src/extensions/components/misc/preview/Button.vue
@@ -4,19 +4,21 @@ import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import TiptapifyDialog from '@tiptapify/components/UI/TiptapifyDialog.vue'
-import { inject, ref, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, ref, Ref, useTemplateRef } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
-const dialog = ref(null)
+const dialog = useTemplateRef('dialog')
 
 </script>
 

--- a/src/extensions/components/misc/source/Button.vue
+++ b/src/extensions/components/misc/source/Button.vue
@@ -3,17 +3,19 @@
 import * as mdi from '@mdi/js'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import ShowSourceDialog from '@tiptapify/extensions/components/misc/source/ShowSourceDialog.vue'
-import { inject, ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, ref, useTemplateRef } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
-const dialog = ref(null)
+const dialog = useTemplateRef('dialog')
 
 function showDialog() {
   dialog.value.showDialog()

--- a/src/extensions/components/misc/source/ShowSourceDialog.vue
+++ b/src/extensions/components/misc/source/ShowSourceDialog.vue
@@ -2,21 +2,23 @@
 import { Editor } from '@tiptap/vue-3'
 import TiptapifyDialog from '@tiptapify/components/UI/TiptapifyDialog.vue'
 import defaults from '@tiptapify/constants/defaults'
-import { ref, watch, inject, Ref } from 'vue'
+import { variantBtnTypes, variantFieldTypes } from '@tiptapify/types/editor'
+import { ref, watch, inject, Ref, PropType, useTemplateRef } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 const props = defineProps({
   indent: { type: Number, default: 2 },
-  variantBtn: { type: String, default: 'elevated' },
-  variantField: { type: String, default: defaults.variantField }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return 'elevated' } },
+  variantField: { type: String as PropType<variantFieldTypes>, default() { return defaults.variantField } },
 })
 
 defineExpose({ showDialog })
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const dialog = ref(null)
+const dialog = useTemplateRef('dialog')
 const formatted = ref(false)
 const sourceCode = ref('')
 
@@ -58,11 +60,11 @@ const unformatHtml = (html: string): string => {
 function showDialog () {
   sourceCode.value = editor.value.getHTML()
 
-  dialog.value.open()
+  dialog.value?.open()
 }
 
 const saveChanges = () => {
-  dialog.value.close()
+  dialog.value?.close()
 
   editor.value.commands.setContent(sourceCode.value, true)
 }

--- a/src/extensions/components/style/StyleColor.vue
+++ b/src/extensions/components/style/StyleColor.vue
@@ -3,8 +3,9 @@
 import { Editor } from '@tiptap/vue-3'
 
 import { computed, inject, Ref, ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 defineExpose({ open, close })
 

--- a/src/extensions/components/style/color/Button.vue
+++ b/src/extensions/components/style/color/Button.vue
@@ -4,18 +4,20 @@ import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import StyleColor from '@tiptapify/extensions/components/style/StyleColor.vue'
-import { computed, inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { computed, inject, PropType, Ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 import { useTheme } from 'vuetify/framework'
 
 import defaults from '@tiptapify/constants/defaults'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const appTheme = useTheme()
 

--- a/src/extensions/components/style/fontFamily/Button.vue
+++ b/src/extensions/components/style/fontFamily/Button.vue
@@ -5,17 +5,19 @@ import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import FontFamily from '@tiptapify/extensions/components/style/fontFamily/FontFamily.vue'
 import { fonts } from '@tiptapify/constants/style'
-import { computed, inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { computed, inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const activeFontFamily = computed(() => {
   let fontFamily = ''

--- a/src/extensions/components/style/fontFamily/FontFamily.vue
+++ b/src/extensions/components/style/fontFamily/FontFamily.vue
@@ -3,13 +3,14 @@
 import { Editor } from '@tiptap/vue-3'
 
 import { computed, inject, Ref, ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 const props = defineProps({
   fonts: { type: Array<{ name: string, fontFamily: string }>, default: [] },
   fontFamily: { type: String, default: '' },
 })
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 

--- a/src/extensions/components/style/fontSize/Button.vue
+++ b/src/extensions/components/style/fontSize/Button.vue
@@ -5,18 +5,20 @@ import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import FontSize from '@tiptapify/extensions/components/style/fontSize/FontSize.vue'
 import { fontSizes } from '@tiptapify/constants/style'
-import { computed, inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { computed, inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 const props = defineProps({
   fontMeasure: { type: String, default () { return 'px' } },
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const activeFontSize = computed(() => {
   let fontSize = null

--- a/src/extensions/components/style/fontSize/FontSize.vue
+++ b/src/extensions/components/style/fontSize/FontSize.vue
@@ -3,6 +3,7 @@
 import { Editor } from '@tiptap/vue-3'
 
 import { computed, inject, Ref, ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 const props = defineProps({
   sizes: { type: Array<number>, default: [] },
@@ -10,7 +11,7 @@ const props = defineProps({
   fontSize: { type: Number, default () { return null } },
 })
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 

--- a/src/extensions/components/style/heading/Button.vue
+++ b/src/extensions/components/style/heading/Button.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 
 import * as mdi from '@mdi/js'
+import { Level } from '@tiptap/extension-heading'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import { variantBtnTypes } from '@tiptapify/types/editor'
@@ -9,7 +10,7 @@ import { inject, PropType, Ref } from 'vue'
 import defaults from '@tiptapify/constants/defaults'
 
 const props = defineProps({
-  customHeadingLevels: { type: Array<number>, default: () => [] },
+  customHeadingLevels: { type: Array<Level>, default: () => [] },
   withParagraph: { type: Boolean, default: () => true },
   variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
@@ -24,7 +25,6 @@ const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 import { headingLevels, setHeadingLevels } from '@tiptapify/constants/style'
 import { ComposerTranslation } from 'vue-i18n'
 setHeadingLevels(props.customHeadingLevels)
-
 </script>
 
 <template>

--- a/src/extensions/components/style/heading/Button.vue
+++ b/src/extensions/components/style/heading/Button.vue
@@ -3,14 +3,15 @@
 import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
-import { inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
 
 const props = defineProps({
   customHeadingLevels: { type: Array<number>, default: () => [] },
   withParagraph: { type: Boolean, default: () => true },
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 interface MDIIcons { [key: string]: string }
@@ -18,9 +19,10 @@ const mdiIcons = mdi as MDIIcons
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 import { headingLevels, setHeadingLevels } from '@tiptapify/constants/style'
+import { ComposerTranslation } from 'vue-i18n'
 setHeadingLevels(props.customHeadingLevels)
 
 </script>

--- a/src/extensions/components/style/highlight/Button.vue
+++ b/src/extensions/components/style/highlight/Button.vue
@@ -4,18 +4,20 @@ import * as mdi from '@mdi/js'
 import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import StyleColor from '@tiptapify/extensions/components/style/StyleColor.vue'
-import { computed, inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { computed, inject, PropType, Ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 import { useTheme } from 'vuetify/framework'
 
 import defaults from '@tiptapify/constants/defaults'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const appTheme = useTheme()
 

--- a/src/extensions/components/style/lineHeight/Button.vue
+++ b/src/extensions/components/style/lineHeight/Button.vue
@@ -5,17 +5,19 @@ import { Editor } from '@tiptap/vue-3'
 import BtnIcon from '@tiptapify/components/UI/BtnIcon.vue'
 import LineHeight from '@tiptapify/extensions/components/style/lineHeight/LineHeight.vue'
 import { lineHeights } from '@tiptapify/constants/style'
-import { computed, inject, Ref } from 'vue'
+import { variantBtnTypes } from '@tiptapify/types/editor'
+import { computed, inject, PropType, Ref } from 'vue'
 
 import defaults from '@tiptapify/constants/defaults'
+import { ComposerTranslation } from 'vue-i18n'
 
 defineProps({
-  variantBtn: { type: String, default: defaults.variantBtn }
+  variantBtn: { type: String as PropType<variantBtnTypes>, default() { return defaults.variantBtn } },
 })
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const activeLineHeight = computed(() => {
   let lineHeight = null

--- a/src/extensions/components/style/lineHeight/FontFamily.vue
+++ b/src/extensions/components/style/lineHeight/FontFamily.vue
@@ -3,13 +3,14 @@
 import { Editor } from '@tiptap/vue-3'
 
 import { computed, inject, Ref, ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 const props = defineProps({
   fonts: { type: Array<{ name: string, fontFamily: string }>, default: [] },
   fontFamily: { type: String, default: '' },
 })
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const emit = defineEmits(['close'])
 

--- a/src/extensions/components/style/lineHeight/LineHeight.vue
+++ b/src/extensions/components/style/lineHeight/LineHeight.vue
@@ -3,13 +3,14 @@
 import { Editor } from '@tiptap/vue-3'
 
 import { computed, inject, Ref, ref } from 'vue'
+import { ComposerTranslation } from 'vue-i18n'
 
 const props = defineProps({
   lineHeights: { type: Array<number>, default () { return [] } },
   lineHeight: { type: Number, default () { return null } },
 })
 
-const { t } = inject('tiptapifyI18n') as any
+const { t } = inject('tiptapifyI18n') as { t: ComposerTranslation }
 
 const editor = inject('tiptapifyEditor') as Ref<Editor>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import Tiptapify from '@tiptapify/components/Tiptapify.vue'
 import TiptapifyDialog from '@tiptapify/components/UI/TiptapifyDialog.vue'
 
 import { Editor as TipTapEditor } from '@tiptap/vue-3'
-import { Node, Mark, mergeAttributes } from '@tiptap/core'
+import { Node, Mark, markInputRule, markPasteRule, mergeAttributes } from '@tiptap/core'
+import type { CommandProps, InputRuleMatch, PasteRuleMatch } from '@tiptap/core'
 
 import * as mdi from '@mdi/js'
 
@@ -25,9 +26,18 @@ const TiptapifyPlugin: Plugin = {
   }
 }
 
-export { Tiptapify, TiptapifyDialog }
 export default TiptapifyPlugin
 
-export { mdi }
-export { TipTapEditor }
-export { Node, Mark, mergeAttributes }
+export {
+  mdi,
+  TipTapEditor,
+  Tiptapify,
+  TiptapifyDialog,
+  Node,
+  Mark,
+  markInputRule,
+  markPasteRule,
+  mergeAttributes,
+}
+
+export type { CommandProps, InputRuleMatch, PasteRuleMatch }

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,0 +1,10 @@
+import { Editor } from '@tiptap/vue-3'
+
+declare class TiptapifyEditor extends Editor {
+  interactiveStyles: boolean | undefined
+}
+
+export { TiptapifyEditor }
+
+export type variantBtnTypes = 'outlined' | 'plain' | 'flat' | 'text' | 'elevated' | 'tonal' | undefined
+export type variantFieldTypes = 'outlined' | 'plain' | 'filled' | 'solo' | 'solo-filled' | 'solo-inverted' | 'underlined' | undefined

--- a/src/types/toolbarTypes.ts
+++ b/src/types/toolbarTypes.ts
@@ -1,3 +1,5 @@
+import { Component } from 'vue'
+
 export enum ToolbarSectionsEnum {
   actions = 'actions',
   alignment = 'alignment',
@@ -12,7 +14,7 @@ export enum ToolbarSectionsEnum {
 
 export type sectionComponent = {
   name: string,
-  component: any,
+  component: Component,
   props?: { [key: string]: any }
 }
 


### PR DESCRIPTION
- Replace `as any` casts with proper typed injections for editor and i18n
- Add `variantBtnTypes` and `variantFieldTypes` union types in `src/types/editor.ts`
- Use `PropType` generics for typed component props
- Migrate template refs to `useTemplateRef` in dialogs
- Convert prop defaults to factory function syntax
- Rename link extension to `tiptapify_link` with typed commands
- Reorganize and export additional types and utilities from `src/index.ts`
- Add `TiptapifyEditor`, `variantBtnTypes`, `variantFieldTypes` to types.md
- Document re-exports: Node, Mark, mergeAttributes, markInputRule, markPasteRule, CommandProps, InputRuleMatch, PasteRuleMatch, mdi, TipTapEditor, Tiptapify, TiptapifyDialog
- Update `editor-ready` payload type from `Editor` to `TiptapifyEditor`
- Reference typed prop variants in props.md
- Rename items import to toolbarItemsGroups to avoid prop name collision in Toolbar/Index.vue
- Remove propsItemsIsList computed property, use inline Array.isArray instead
- Upgrade types: sectionComponent.component → Component, heading levels → Level[], more specific type annotations
- Parse heading options as integers - fixes not working heading styling when custom heading toolbar items provided
- Fix invalid CSS margin: none → margin: unset in Tiptapify.vue